### PR TITLE
Apply shellcheck fixes

### DIFF
--- a/src/output-analysis/parsing/run_parse_consensus_tree_PhyloWGS.sh
+++ b/src/output-analysis/parsing/run_parse_consensus_tree_PhyloWGS.sh
@@ -26,7 +26,7 @@ do
     for patient in ${patients[@]} 
     do
         Rscript /hot/users/psteinberg/work-code/parse_consensus_tree_PhyloWGS.R \
-        -s /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-phylowgs/output/call-SRC-1.1.0/${patient}/PhyloWGS-2205be1/output/PhyloWGS-2205be1_${seed}_${patient}_SomaticSniper-Battenberg.summ.json.gz \
+        -s /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-phylowgs/output/call-SRC-1.1.0/"${patient}"/PhyloWGS-2205be1/output/PhyloWGS-2205be1_"${seed}"_"${patient}"_SomaticSniper-Battenberg.summ.json.gz \
         -o /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-phylowgs/output/consensus_tree
     done
 done

--- a/src/output-analysis/plotting/plotting_workflow.sh
+++ b/src/output-analysis/plotting/plotting_workflow.sh
@@ -2,16 +2,16 @@
 projectdir=/hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/
 workdir=/hot/user/yiyangliu/repo/project-AlgorithmEvaluation-BNCH-000082-SRCRNDSeed/src/output-analysis/plotting/
 
-cd ${workdir}
+cd ${workdir} || exit
 for snv in Strelka2 Mutect2 SomaticSniper; do echo ${snv}
     for src in DPClust PhyloWGS PyClone-VI; do echo ${src}
         for mode in sr mr; do echo ${mode}
-            snvl=${snv,,}; echo ${snvl}
-            srcl=${src,,}; echo ${srcl}
-            file=$(ls ${projectdir}/pipeline-call-src/run-${snvl}-battenberg-${srcl}/output/*${snvl}_battenberg_${srcl}_${mode}.tsv -Art | tail -n 1)
-            echo ${file}
+            snvl=${snv,,}; echo "${snvl}"
+            srcl=${src,,}; echo "${srcl}"
+            file=$(ls ${projectdir}/pipeline-call-src/run-"${snvl}"-battenberg-"${srcl}"/output/*"${snvl}"_battenberg_"${srcl}"_${mode}.tsv -Art | tail -n 1)
+            echo "${file}"
             if [ -f "$file" ]; then
-                Rscript ${workdir}/subclone_relative_seed_variability.R -f ${file} -p ${snv}-Battenberg-${src} -m ${mode} -o ${projectdir}/pipeline-call-src/plots/stripplot2
+                Rscript ${workdir}/subclone_relative_seed_variability.R -f "${file}" -p ${snv}-Battenberg-${src} -m ${mode} -o ${projectdir}/pipeline-call-src/plots/stripplot2
             fi
         done
     done

--- a/src/run-pipeline-call-src/mr_mutect2_battenberg_pyclone-vi_submission_script.sh
+++ b/src/run-pipeline-call-src/mr_mutect2_battenberg_pyclone-vi_submission_script.sh
@@ -20,7 +20,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 30
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -29,9 +29,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-mutect2-battenberg-pyclone-vi/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/mutect2_battenberg_yamls/multi-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_Mutect2-Battenberg-PyClone-VI-mr \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-mutect2-battenberg-pyclone-vi/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/mutect2_battenberg_yamls/multi-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_Mutect2-Battenberg-PyClone-VI-mr \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/mr_somaticsniper_battenberg_pyclone-vi_submission_script.sh
+++ b/src/run-pipeline-call-src/mr_somaticsniper_battenberg_pyclone-vi_submission_script.sh
@@ -20,7 +20,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 30
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -29,9 +29,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-pyclone-vi/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/somaticsniper_battenberg_yamls/multi-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_SomaticSniper-Battenberg-PyClone-VI-mr \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-pyclone-vi/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/somaticsniper_battenberg_yamls/multi-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_SomaticSniper-Battenberg-PyClone-VI-mr \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/mr_strelka2_battenberg_pyclone-vi_submission_script.sh
+++ b/src/run-pipeline-call-src/mr_strelka2_battenberg_pyclone-vi_submission_script.sh
@@ -20,7 +20,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 60
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -29,9 +29,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-strelka2-battenberg-pyclone-vi/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/strelka2_battenberg_yamls/multi-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_Strelka2-Battenberg-PyClone-VI-mr \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-strelka2-battenberg-pyclone-vi/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/strelka2_battenberg_yamls/multi-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_Strelka2-Battenberg-PyClone-VI-mr \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_mutect2_battenberg_dpclust_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_mutect2_battenberg_dpclust_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 240
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-mutect2-battenberg-dpclust/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/mutect2_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_Mutect2-Battenberg-DPClust-sr \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-mutect2-battenberg-dpclust/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/mutect2_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_Mutect2-Battenberg-DPClust-sr \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_mutect2_battenberg_phylowgs_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_mutect2_battenberg_phylowgs_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 30
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 6 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/software/pipeline/pipeline-call-SRC/Nextflow/release/1.0.0-rc.1/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-mutect2-battenberg-phylowgs/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/mutect2_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_Mutect2-Battenberg-PhyloWGS \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-mutect2-battenberg-phylowgs/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/mutect2_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_Mutect2-Battenberg-PhyloWGS \
             --partition_type F72 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_mutect2_battenberg_pyclone-vi_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_mutect2_battenberg_pyclone-vi_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 30
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-mutect2-battenberg-pyclone-vi/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/mutect2_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_Mutect2-Battenberg-PyClone-VI \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-mutect2-battenberg-pyclone-vi/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/mutect2_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_Mutect2-Battenberg-PyClone-VI \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_somaticsniper_battenberg_dpclust_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_somaticsniper_battenberg_dpclust_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 240
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-dpclust/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/somaticsniper_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_SomaticSniper-Battenberg-DPClust \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-dpclust/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/somaticsniper_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_SomaticSniper-Battenberg-DPClust \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_somaticsniper_battenberg_phylowgs_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_somaticsniper_battenberg_phylowgs_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 60
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-phylowgs/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/somaticsniper_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_SomaticSniper-Battenberg-PhyloWGS-sr \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-phylowgs/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/somaticsniper_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_SomaticSniper-Battenberg-PhyloWGS-sr \
             --partition_type F72 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_somaticsniper_battenberg_pyclone-vi_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_somaticsniper_battenberg_pyclone-vi_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 60
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-pyclone-vi/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/somaticsniper_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_SomaticSniper-Battenberg-PyClone-VI \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-somaticsniper-battenberg-pyclone-vi/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/somaticsniper_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_SomaticSniper-Battenberg-PyClone-VI \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_strelka2_battenberg_dpclust_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_strelka2_battenberg_dpclust_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 240
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-strelka2-battenberg-dpclust/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/strelka2_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_Strelka2-Battenberg-DPClust \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-strelka2-battenberg-dpclust/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/strelka2_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_Strelka2-Battenberg-DPClust \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_strelka2_battenberg_phylowgs_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_strelka2_battenberg_phylowgs_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 300
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 6 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/software/pipeline/pipeline-call-SRC/Nextflow/release/1.0.0-rc.1/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-strelka2-battenberg-phylowgs/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/strelka2_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_Strelka2-Battenberg-PhyloWGS \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-strelka2-battenberg-phylowgs/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/strelka2_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_Strelka2-Battenberg-PhyloWGS \
             --partition_type F72 \
             --email psteinberg@mednet.ucla.edu
     done

--- a/src/run-pipeline-call-src/sr_strelka2_battenberg_pyclone-vi_submission_script.sh
+++ b/src/run-pipeline-call-src/sr_strelka2_battenberg_pyclone-vi_submission_script.sh
@@ -27,7 +27,7 @@ do
         while [ $submit_signal == "false" ]
         do
             sleep 60
-            jobs_running=$((`squeue -u psteinberg | wc -l` - 1))
+            jobs_running=$(($(squeue -u psteinberg | wc -l) - 1))
             echo "jobs running: $jobs_running"
             if [ $jobs_running -lt 5 ]
             then
@@ -36,9 +36,9 @@ do
         done
         python3 /hot/software/package/tool-submit-nf/Python/release/2.2.0/submit_nextflow_pipeline.py \
             --nextflow_script /hot/user/yashpatel/pipeline-call-SRC/pipeline-call-SRC/main.nf \
-            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-strelka2-battenberg-pyclone-vi/input/config/seed_${seed}.config \
-            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/strelka2_battenberg_yamls/single-region/${patient}.yaml \
-            --pipeline_run_name ${patient}_${seed}_Strelka2-Battenberg-PyClone-VI \
+            --nextflow_config /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/run-strelka2-battenberg-pyclone-vi/input/config/seed_"${seed}".config \
+            --nextflow_yaml /hot/project/method/AlgorithmEvaluation/BNCH-000082-SRCRNDSeed/pipeline-call-src/strelka2_battenberg_yamls/single-region/"${patient}".yaml \
+            --pipeline_run_name "${patient}"_"${seed}"_Strelka2-Battenberg-PyClone-VI \
             --partition_type F32 \
             --email psteinberg@mednet.ucla.edu
     done


### PR DESCRIPTION
[Shellcheck](https://github.com/koalaman/shellcheck) is a tool for finding problematic code in shell scripts, from syntax errors to subtle and non-intuitive [pitfalls](https://mywiki.wooledge.org/BashPitfalls). It is also capable of automatically fixed some kinds of issues.

Eventually shellcheck will be enabled in the CI/CD checks (i.e. the linters) used by this repository. In order to ease that transition (and make your life easier!), this PR includes all code fixes that could be performed automatically.

**None of these fixes have been tested** - this pull request was generated by a script and should be reviewed _very closely_.

These changes make the shell scripts in this repository abide by the following shellcheck rules:
* [Double quote array expansions to avoid re-splitting elements.](https://www.shellcheck.net/wiki/SC2068)
* [Use 'cd ... || exit' or 'cd ... || return' in case cd fails.](https://www.shellcheck.net/wiki/SC2164)
* [Use find instead of ls to better handle non-alphanumeric filenames.](https://www.shellcheck.net/wiki/SC2012)
* [Double quote to prevent globbing and word splitting.](https://www.shellcheck.net/wiki/SC2086)
* [Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.](https://www.shellcheck.net/wiki/SC2148)
* [Use $(...) notation instead of legacy backticks `...`.](https://www.shellcheck.net/wiki/SC2006)
* [Use spaces, not commas, to separate array elements.](https://www.shellcheck.net/wiki/SC2054)

There were also warnings that could not be fixed automatically:

```console

In src/test-pipeline-call-src/input/submission_script.sh line 1:
# Submission script for test running pipeline-call-SRC #3 https://github.com/uclahs-cds/project-SRC-RandomSeed/issues/3
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/test-pipeline-call-src/test-strelka2/input/strelka2_submission_script.sh line 1:
# Submission script for test running pipeline-call-SRC for strelka
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/test-pipeline-call-src/test-somaticsniper/input/submission_script.sh line 1:
# submission script for test of pipeline-call-SRC
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_strelka2_battenberg_phylowgs_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode Strelka2-Battenberg-PhyloWGS)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_strelka2_battenberg_phylowgs_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_strelka2_battenberg_phylowgs_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_strelka2_battenberg_dpclust_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode Strelka2-Battenberg-DPClust)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_strelka2_battenberg_dpclust_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_strelka2_battenberg_dpclust_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/mr_strelka2_battenberg_pyclone-vi_submission_script.sh line 1:
# Submission script for SRC pipeline (multi-region mode Strelka2-Battenberg-PyClone-VI)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/mr_strelka2_battenberg_pyclone-vi_submission_script.sh line 14:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/mr_strelka2_battenberg_pyclone-vi_submission_script.sh line 16:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_mutect2_battenberg_phylowgs_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode Mutect2-Battenberg-PhyloWGS)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_mutect2_battenberg_phylowgs_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_mutect2_battenberg_phylowgs_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/mr_mutect2_battenberg_pyclone-vi_submission_script.sh line 1:
# Submission script for SRC pipeline (multi-region mode Mutect2-Battenberg-PyClone-VI)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/mr_mutect2_battenberg_pyclone-vi_submission_script.sh line 14:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/mr_mutect2_battenberg_pyclone-vi_submission_script.sh line 16:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_mutect2_battenberg_dpclust_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode Mutect2-Battenberg-DPClust)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_mutect2_battenberg_dpclust_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_mutect2_battenberg_dpclust_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_phylowgs_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode SomaticSniper-Battenberg_Phylowgs)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_phylowgs_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_phylowgs_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_dpclust_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode SomaticSniper-Battenberg-DPClust)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_dpclust_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_dpclust_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/mr_somaticsniper_battenberg_pyclone-vi_submission_script.sh line 1:
# Submission script for SRC pipeline (multi-region mode SomaticSniper-Battenberg-PyClone-VI)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/mr_somaticsniper_battenberg_pyclone-vi_submission_script.sh line 14:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/mr_somaticsniper_battenberg_pyclone-vi_submission_script.sh line 16:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_pyclone-vi_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode SomaticSniper-Battenberg-PyClone-VI)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_pyclone-vi_submission_script.sh line 3:
seeds=("51404", "366306" "423647" "838004" "50135" "628019" "97782" "253505" "659767" "13142")
      ^-- SC2054 (warning): Use spaces, not commas, to separate array elements.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_pyclone-vi_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_somaticsniper_battenberg_pyclone-vi_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_mutect2_battenberg_pyclone-vi_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode Mutect2-Battenberg-PyClone-VI)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_mutect2_battenberg_pyclone-vi_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_mutect2_battenberg_pyclone-vi_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_strelka2_battenberg_pyclone-vi_submission_script.sh line 1:
# Submission script for SRC pipeline (single-region mode Strelka2-Battenberg-PyClone-VI)
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/run-pipeline-call-src/sr_strelka2_battenberg_pyclone-vi_submission_script.sh line 21:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/run-pipeline-call-src/sr_strelka2_battenberg_pyclone-vi_submission_script.sh line 23:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/output-analysis/plotting/plotting_workflow.sh line 1:
# stripplot for relative seed variability in number of subclones called
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/output-analysis/plotting/plotting_workflow.sh line 11:
            file=$(ls ${projectdir}/pipeline-call-src/run-"${snvl}"-battenberg-"${srcl}"/output/*"${snvl}"_battenberg_"${srcl}"_${mode}.tsv -Art | tail -n 1)
                   ^-- SC2012 (info): Use find instead of ls to better handle non-alphanumeric filenames.


In src/output-analysis/parsing/run_parse_consensus_tree_PhyloWGS.sh line 1:
# Submission script for creating consensus tree (PhyloWGS) for each pipeline x sample x seed output
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In src/output-analysis/parsing/run_parse_consensus_tree_PhyloWGS.sh line 24:
for seed in ${seeds[@]} 
            ^---------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/output-analysis/parsing/run_parse_consensus_tree_PhyloWGS.sh line 26:
    for patient in ${patients[@]} 
                   ^------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.


In src/test-parser/parser_test_script.sh line 1:
# script for testing SRC pipeline parser
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...
  https://www.shellcheck.net/wiki/SC2054 -- Use spaces, not commas, to separa...
```


If any of these fixes/warnings are incorrect, shellcheck can be silenced by adding a line like `#shellcheck disable=<rule name>` immediately before the offending line ([docs](https://github.com/koalaman/shellcheck/wiki/Ignore#ignoring-one-specific-instance-in-a-file)).