### PR TITLE
Update subclone_relative_seed_variability.R

### DIFF
--- a/src/output-analysis/plotting/subclone_relative_seed_variability.R
+++ b/src/output-analysis/plotting/subclone_relative_seed_variability.R
@@ -85,8 +85,6 @@ subclones.data.toplot <- process.subclones.for.plotting.mode(subclones.data)
 
 # reprocess symbols into a matrix as should be plotted
 symbol.matrix <- matrix(subclones.data.toplot$compare, nrow = length(unique(subclones.data.toplot$patient)), ncol = length(seeds), byrow = TRUE)
-# reverse rows since row order is reversed in a heatmap
-symbol.matrix <- symbol.matrix[nrow(symbol.matrix):1, ]
 # output every index of the matrix to indicate where each symbol should go
 nclones.ind <- which(symbol.matrix != '', arr.ind = TRUE);
 nclones.x <- nclones.ind[, 2];
@@ -101,7 +99,6 @@ nclones.text <- nclones.3.cex[nclones.text]
 
 # get all colours in the order of the indices
 col.matrix <- matrix(subclones.data.toplot$col, nrow = length(unique(subclones.data.toplot$patient)), ncol = length(seeds), byrow = TRUE)
-col.matrix <- col.matrix[nrow(col.matrix):1, ]
 nclones.col <- apply(nclones.ind, 1, function(x) col.matrix[x[1], x[2]])
 
 nclones.pos <- rep(3, length(nclones.text));


### PR DESCRIPTION
Changed to heatmap plotting of symbols

# Description
<!--- Briefly describe the changes included in this pull request  --->
Changed the stripplot to heatmap plots. 

Example command:

```
Rscript ./subclone_relative_seed_variability.R \
-f ./data/2023-04-02_num_subclones_mutect2_battenberg_dpclust_sr.tsv \
-p Mutect2-Battenberg-DPClust \
-m sr \
-o ./plots/seed/
```

Example output:
[2024-01-30_proj-seed_Mutect2-Battenberg-DPClust_sr_seed_variability.pdf](https://github.com/uclahs-cds/project-method-AlgorithmEvaluation-BNCH-000082-SRCRNDSeed/files/14104988/2024-01-30_proj-seed_Mutect2-Battenberg-DPClust_sr_seed_variability.pdf)


<!-- 
Admin/maintainer: please edit the 'Pipeline Run Results' or 'Analysis Results' sections as needed for your project repo.  
Then commit/push the changes so everyone uses this template for future PRs.

For example, if your project is a `pipeline`, then create a 'Pipeline Run Results' section.

If your project is a general data analysis project, then you may want to require an 'Analysis Results' section in order to test
code from each PR to help prevent creating new bugs.
-->

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [x] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.


- [x] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

